### PR TITLE
Adding URLs for Pub. L. cite matches

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -129,7 +129,7 @@ d3.json('index.json', function(err, index) {
                 if (cite.type == "dc_code")
                     return "<a href=\"" + urlFor(cite) + "\">" + cite.match + "</a>";
                 else if (cite.type == "law")
-                    return "law";
+                    return "<a href=\"" + "http://www.govtrack.us/search?q=" + cite.match.replace(" ","%20") + "\">" + cite.match + "</a>";
             }
         }).text;
     }


### PR DESCRIPTION
After Eric added the law.js library to the citations portion of the browser, we included the ability to link to the govtrack public law searching
