### PR TITLE
add parens around section prefixes (just use CSS)

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -254,6 +254,14 @@ section .section-prefix {
     color:#777;
 }
 
+section .section-prefix:before {
+    content:"(";
+}
+
+section .section-prefix:after {
+    content:")";
+}
+
 .limited-text {
     border-top:1px solid #ccc;
     background:#eee;


### PR DESCRIPTION
Add parentheses around the section prefixes, as requested by @vzvenyach.
