### PR TITLE
increase indents in hierarchy and add 2 more levels (lc & uc roman)

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -240,12 +240,24 @@ section {
     padding:10px 5px;
 }
 
+section.section-1 {
+    margin-left:2em;
+}
+
 section.section-2 {
-    margin-left:10px;
+    margin-left:4em;
 }
 
 section.section-3 {
-    margin-left:20px;
+    margin-left:6em;
+}
+
+section.section-4 {
+    margin-left:8em;
+}
+
+section.section-5 {
+    margin-left:10em;
 }
 
 section .section-prefix {

--- a/js/browser.js
+++ b/js/browser.js
@@ -33,7 +33,11 @@ function doesNotApply(d) {
 
 function sectionClass(d) {
     var c = '';
-    if (d.prefix.match(/([a-z])/)) c = 'section-1';
+    // Really need context (at least the previous prefix to know whether
+    // i is a lowercase letter or a lowercase roman numeral.
+    if (d.prefix.match(/^[ivx]+$/)) c = 'section-4';
+    else if (d.prefix.match(/^[IVX]+$/)) c = 'section-5';
+    else if (d.prefix.match(/([a-z])/)) c = 'section-1';
     else if (d.prefix.match(/([0-9])/)) c = 'section-2';
     else if (d.prefix.match(/([A-Z])/)) c = 'section-3';
     return c;


### PR DESCRIPTION
There are further hierarchy levels (section-4 and section-5) for lowercase and uppercase roman numerals. This hack ignores the possibility that "i" or "I" is actually part of an alphabetic sequence, but obviously the function to determine hierarchy level needs to be smarter (needs to know the previous prefix at least, and ideally the next too, in case "h" has roman numerals under it).

Also, I increased the indent from 10px (which seems too small) to 2em and indented the "(a)" level too. 
