### PR TITLE
Improve look of the json download link

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -280,6 +280,17 @@ section .section-prefix:after {
     color: #666;
 }
 
+.download {
+    border-top:1px solid #ccc;
+    padding-left: 20px;
+    color: #777;
+}
+
+.download span {
+    background: url(../img/download.svg) 0 0 no-repeat;
+    padding-left: 24px;
+}
+
 .pad1.small-top {
     padding-top:0;
     border-bottom:1px solid #eee;

--- a/img/download.svg
+++ b/img/download.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<polygon fill="#999999" points="13.6,9.424 13.6,13.534 2.398,13.534 2.398,9.424 0,9.424 0,16 16,16 16,9.424 "/>
+<polygon fill="#999999" points="9.6,6.288 9.6,3 6.398,3 6.398,6.288 3.52,6.288 8,11.043 12.48,6.288 "/>
+</svg>

--- a/js/browser.js
+++ b/js/browser.js
@@ -190,7 +190,7 @@ d3.json('index.json').on('load', function(index) {
             extra_sections.append('h4').text(function(d) { return d.title; });
             extra_sections.append('p').html(function(d) { return cited(d.text); });
 
-            var downloads = div.append('p').attr('class', 'pad1');
+            var downloads = div.append('div').attr('class', 'pad21h download no-print');
             downloads.append('span').text('download: ');
             downloads.append('a')
                 .text(function(d) { return d.heading.identifier + '.json'; })


### PR DESCRIPTION
Some improvements to the download link:
- Make left margin same as the rest of the page
- Add a top border which separates the download link from the rest of the page (the effect is more obvious when you view a section of code that doesn't have credits or history)
- Add a download icon (opting for a modified version of this [this icon](http://thenounproject.com/noun/download/#icon-No4501) (licensed CC0) rather than the typicons font)
- Make the download link not appear on printing
